### PR TITLE
chore: upgrade to be ruby3 compatible

### DIFF
--- a/lib/simple_service/context.rb
+++ b/lib/simple_service/context.rb
@@ -139,7 +139,7 @@ module SimpleService
       ]
       options[:default] = defaults
 
-      SimpleService::Configuration.i18n.translate(key, options)
+      SimpleService::Configuration.i18n.translate(key, **options)
     end
 
     def get_message(msg, type)


### PR DESCRIPTION
This pull request is to help make the `simple_service` gem compatible for ruby 3